### PR TITLE
Added esc as delete key

### DIFF
--- a/src/main/java/seedu/address/ui/CommandBox.java
+++ b/src/main/java/seedu/address/ui/CommandBox.java
@@ -3,6 +3,7 @@ package seedu.address.ui;
 import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
 import javafx.scene.control.TextField;
+import javafx.scene.input.KeyCode;
 import javafx.scene.layout.Region;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
@@ -29,6 +30,12 @@ public class CommandBox extends UiPart<Region> {
         this.commandExecutor = commandExecutor;
         // calls #setStyleToDefault() whenever there is a change to the text of the command box.
         commandTextField.textProperty().addListener((unused1, unused2, unused3) -> setStyleToDefault());
+        commandTextField.setOnKeyPressed(event -> {
+            if (event.getCode() == KeyCode.ESCAPE) {
+                commandTextField.clear();
+                event.consume();
+            }
+        });
     }
 
     /**


### PR DESCRIPTION
## Summary

Closes #

## Description of Changes

This PR adds a keyboard shortcut to quickly clear the command/search bar after command input is preserved.

### Problem
After changing command input behavior to remain in the command box, users needed a fast way to clear it manually.

### What changed
- Added a key handler in `CommandBox`:
  - Pressing `Esc` clears the command box text.
- Chosen key is cross-platform and works on both macOS and Windows keyboards.
