### PR TITLE
Fix #119 manual test room format wording

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -520,7 +520,7 @@ testers are expected to do more *exploratory* testing.
    1. Prerequisites: Multiple residents with different names, rooms, and phone numbers.
    
    1. Test case: `list -sort r/`<br>
-      Expected: List is updated to show all residents sorted by room number (format: #BLOCK-ROOM-LETTER). Status message confirms sorting.
+      Expected: List is updated to show all residents sorted by room number (format: #BLOCK-ROOM[-LETTER]). Status message confirms sorting.
 
    1. Test case: `list -sort p/`<br>
       Expected: List is updated to show all residents sorted by their phone numbers.


### PR DESCRIPTION
## Summary
- Verify the room format accepted by the current codebase
- Update the inaccurate manual test wording in `docs/DeveloperGuide.md`

Closes #119