### PR TITLE
Added find by tag

### DIFF
--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -18,12 +18,13 @@ public class FindCommand extends Command {
     public static final String COMMAND_WORD = "find";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Finds all persons whose names contain any of the specified keywords (case-insensitive), "
-            + "or whose room contains the specified room fragment, and displays them as a list with index numbers.\n"
-            + "Parameters: KEYWORD [MORE_KEYWORDS]... | ROOM\n"
+            + ": Finds all persons whose names, rooms, or tags contain any of the specified keywords "
+            + "(case-insensitive), and displays them as a list with index numbers.\n"
+            + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
             + "Examples:\n"
             + "  " + COMMAND_WORD + " alice bob charlie\n"
-            + "  " + COMMAND_WORD + " #14-2";
+            + "  " + COMMAND_WORD + " #14-2\n"
+            + "  " + COMMAND_WORD + " friend";
 
     private final Predicate<Person> predicate;
 

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -6,8 +6,7 @@ import java.util.Arrays;
 
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.model.person.NameContainsKeywordsPredicate;
-import seedu.address.model.person.RoomEqualsPredicate;
+import seedu.address.model.person.PersonContainsKeywordsPredicate;
 
 /**
  * Parses input arguments and creates a new FindCommand object
@@ -27,13 +26,8 @@ public class FindCommandParser implements Parser<FindCommand> {
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
         }
 
-        if (trimmedArgs.startsWith("#")) {
-            return new FindCommand(new RoomEqualsPredicate(trimmedArgs));
-        }
-
-        String[] nameKeywords = trimmedArgs.split("\\s+");
-
-        return new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
+        String[] keywords = trimmedArgs.split("\\s+");
+        return new FindCommand(new PersonContainsKeywordsPredicate(Arrays.asList(keywords)));
     }
 
 }

--- a/src/main/java/seedu/address/model/person/PersonContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/PersonContainsKeywordsPredicate.java
@@ -1,0 +1,50 @@
+package seedu.address.model.person;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+import seedu.address.commons.util.ToStringBuilder;
+
+/**
+ * Tests that a {@code Person}'s name, room, or tags match any of the keywords given.
+ */
+public class PersonContainsKeywordsPredicate implements Predicate<Person> {
+    private final List<String> keywords;
+
+    public PersonContainsKeywordsPredicate(List<String> keywords) {
+        this.keywords = keywords;
+    }
+
+    @Override
+    public boolean test(Person person) {
+        String personName = person.getName().fullName.toLowerCase();
+        String personRoom = person.getRoom().value.toLowerCase();
+
+        return keywords.stream()
+                .map(String::toLowerCase)
+                .anyMatch(keyword -> personName.contains(keyword)
+                        || personRoom.contains(keyword)
+                        || person.getTags().stream()
+                        .map(tag -> tag.getTagName().toLowerCase())
+                        .anyMatch(tagName -> tagName.contains(keyword)));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        if (!(other instanceof PersonContainsKeywordsPredicate)) {
+            return false;
+        }
+
+        PersonContainsKeywordsPredicate otherPredicate = (PersonContainsKeywordsPredicate) other;
+        return keywords.equals(otherPredicate.keywords);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this).add("keywords", keywords).toString();
+    }
+}

--- a/src/main/java/seedu/address/model/person/PersonContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/PersonContainsKeywordsPredicate.java
@@ -1,8 +1,8 @@
 package seedu.address.model.person;
 
 import java.util.List;
-import java.util.function.Predicate;
 import java.util.Objects;
+import java.util.function.Predicate;
 
 import seedu.address.commons.util.ToStringBuilder;
 
@@ -11,7 +11,12 @@ import seedu.address.commons.util.ToStringBuilder;
  */
 public class PersonContainsKeywordsPredicate implements Predicate<Person> {
     private final List<String> keywords;
-
+    /**
+     * Constructs a PersonContainsKeywordsPredicate with the given keywords.
+     *
+     * @param keywords the keywords to match against person attributes
+     * @throws NullPointerException if keywords is null
+     */
     public PersonContainsKeywordsPredicate(List<String> keywords) {
         Objects.requireNonNull(keywords, "Keywords cannot be null");
         this.keywords = keywords;

--- a/src/main/java/seedu/address/model/person/PersonContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/PersonContainsKeywordsPredicate.java
@@ -2,6 +2,7 @@ package seedu.address.model.person;
 
 import java.util.List;
 import java.util.function.Predicate;
+import java.util.Objects;
 
 import seedu.address.commons.util.ToStringBuilder;
 

--- a/src/main/java/seedu/address/model/person/PersonContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/PersonContainsKeywordsPredicate.java
@@ -12,6 +12,7 @@ public class PersonContainsKeywordsPredicate implements Predicate<Person> {
     private final List<String> keywords;
 
     public PersonContainsKeywordsPredicate(List<String> keywords) {
+        Objects.requireNonNull(keywords, "Keywords cannot be null");
         this.keywords = keywords;
     }
 

--- a/src/test/java/seedu/address/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindCommandTest.java
@@ -11,6 +11,7 @@ import static seedu.address.testutil.TypicalPersons.CARL;
 import static seedu.address.testutil.TypicalPersons.ELLE;
 import static seedu.address.testutil.TypicalPersons.FIONA;
 import static seedu.address.testutil.TypicalPersons.GEORGE;
+import static seedu.address.testutil.TypicalPersons.HANNAH;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import java.util.Arrays;
@@ -91,11 +92,11 @@ public class FindCommandTest {
     @Test
     public void execute_tagMatch_personsFound() {
         String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 2);
-        PersonContainsKeywordsPredicate predicate = preparePredicate("friend");
+        PersonContainsKeywordsPredicate predicate = preparePredicate("allerg");
         FindCommand command = new FindCommand(predicate);
         expectedModel.updateFilteredPersonList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
-        assertEquals(Arrays.asList(ALICE, BENSON), model.getFilteredPersonList());
+        assertEquals(Arrays.asList(BENSON, HANNAH), model.getFilteredPersonList());
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindCommandTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.Messages.MESSAGE_PERSONS_LISTED_OVERVIEW;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.testutil.TypicalPersons.ALICE;
+import static seedu.address.testutil.TypicalPersons.BENSON;
 import static seedu.address.testutil.TypicalPersons.CARL;
 import static seedu.address.testutil.TypicalPersons.ELLE;
 import static seedu.address.testutil.TypicalPersons.FIONA;
@@ -21,8 +22,7 @@ import org.junit.jupiter.api.Test;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
-import seedu.address.model.person.NameContainsKeywordsPredicate;
-import seedu.address.model.person.RoomEqualsPredicate;
+import seedu.address.model.person.PersonContainsKeywordsPredicate;
 
 /**
  * Contains integration tests (interaction with the Model) for {@code FindCommand}.
@@ -33,10 +33,10 @@ public class FindCommandTest {
 
     @Test
     public void equals() {
-        NameContainsKeywordsPredicate firstPredicate =
-                new NameContainsKeywordsPredicate(Collections.singletonList("first"));
-        NameContainsKeywordsPredicate secondPredicate =
-                new NameContainsKeywordsPredicate(Collections.singletonList("second"));
+        PersonContainsKeywordsPredicate firstPredicate =
+                new PersonContainsKeywordsPredicate(Collections.singletonList("first"));
+        PersonContainsKeywordsPredicate secondPredicate =
+                new PersonContainsKeywordsPredicate(Collections.singletonList("second"));
 
         FindCommand findFirstCommand = new FindCommand(firstPredicate);
         FindCommand findSecondCommand = new FindCommand(secondPredicate);
@@ -61,7 +61,7 @@ public class FindCommandTest {
     @Test
     public void execute_zeroKeywords_noPersonFound() {
         String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 0);
-        NameContainsKeywordsPredicate predicate = preparePredicate(" ");
+        PersonContainsKeywordsPredicate predicate = preparePredicate(" ");
         FindCommand command = new FindCommand(predicate);
         expectedModel.updateFilteredPersonList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
@@ -71,7 +71,7 @@ public class FindCommandTest {
     @Test
     public void execute_multipleKeywords_multiplePersonsFound() {
         String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 3);
-        NameContainsKeywordsPredicate predicate = preparePredicate("Kurz Elle Kunz");
+        PersonContainsKeywordsPredicate predicate = preparePredicate("Kurz Elle Kunz");
         FindCommand command = new FindCommand(predicate);
         expectedModel.updateFilteredPersonList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
@@ -81,11 +81,21 @@ public class FindCommandTest {
     @Test
     public void execute_roomMatch_personFound() {
         String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 1);
-        RoomEqualsPredicate predicate = new RoomEqualsPredicate("#14-2");
+        PersonContainsKeywordsPredicate predicate = preparePredicate("#14-2");
         FindCommand command = new FindCommand(predicate);
         expectedModel.updateFilteredPersonList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
         assertEquals(Collections.singletonList(ALICE), model.getFilteredPersonList());
+    }
+
+    @Test
+    public void execute_tagMatch_personsFound() {
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 2);
+        PersonContainsKeywordsPredicate predicate = preparePredicate("friend");
+        FindCommand command = new FindCommand(predicate);
+        expectedModel.updateFilteredPersonList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Arrays.asList(ALICE, BENSON), model.getFilteredPersonList());
     }
 
     @Test
@@ -95,7 +105,7 @@ public class FindCommandTest {
         model.updateFilteredPersonList(Model.PREDICATE_SHOW_ALL_PERSONS, roomComparator);
 
         String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 2);
-        NameContainsKeywordsPredicate predicate = preparePredicate("Alice George");
+        PersonContainsKeywordsPredicate predicate = preparePredicate("Alice George");
         FindCommand command = new FindCommand(predicate);
         expectedModel.updateFilteredPersonList(predicate);
 
@@ -105,16 +115,16 @@ public class FindCommandTest {
 
     @Test
     public void toStringMethod() {
-        NameContainsKeywordsPredicate predicate = new NameContainsKeywordsPredicate(Arrays.asList("keyword"));
+        PersonContainsKeywordsPredicate predicate = new PersonContainsKeywordsPredicate(Arrays.asList("keyword"));
         FindCommand findCommand = new FindCommand(predicate);
         String expected = FindCommand.class.getCanonicalName() + "{predicate=" + predicate + "}";
         assertEquals(expected, findCommand.toString());
     }
 
     /**
-     * Parses {@code userInput} into a {@code NameContainsKeywordsPredicate}.
+     * Parses {@code userInput} into a {@code PersonContainsKeywordsPredicate}.
      */
-    private NameContainsKeywordsPredicate preparePredicate(String userInput) {
-        return new NameContainsKeywordsPredicate(Arrays.asList(userInput.split("\\s+")));
+    private PersonContainsKeywordsPredicate preparePredicate(String userInput) {
+        return new PersonContainsKeywordsPredicate(Arrays.asList(userInput.split("\\s+")));
     }
 }

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -27,8 +27,8 @@ import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.Comment;
-import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.person.Person;
+import seedu.address.model.person.PersonContainsKeywordsPredicate;
 import seedu.address.testutil.EditPersonDescriptorBuilder;
 import seedu.address.testutil.PersonBuilder;
 import seedu.address.testutil.PersonUtil;
@@ -82,7 +82,7 @@ public class AddressBookParserTest {
         List<String> keywords = Arrays.asList("foo", "bar", "baz");
         FindCommand command = (FindCommand) parser.parseCommand(
                 FindCommand.COMMAND_WORD + " " + keywords.stream().collect(Collectors.joining(" ")));
-        assertEquals(new FindCommand(new NameContainsKeywordsPredicate(keywords)), command);
+        assertEquals(new FindCommand(new PersonContainsKeywordsPredicate(keywords)), command);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -9,8 +9,7 @@ import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.FindCommand;
-import seedu.address.model.person.NameContainsKeywordsPredicate;
-import seedu.address.model.person.RoomEqualsPredicate;
+import seedu.address.model.person.PersonContainsKeywordsPredicate;
 
 public class FindCommandParserTest {
 
@@ -25,7 +24,7 @@ public class FindCommandParserTest {
     public void parse_validArgs_returnsFindCommand() {
         // no leading and trailing whitespaces
         FindCommand expectedFindCommand =
-                new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList("Alice", "Bob")));
+                new FindCommand(new PersonContainsKeywordsPredicate(Arrays.asList("Alice", "Bob")));
         assertParseSuccess(parser, "Alice Bob", expectedFindCommand);
 
         // multiple whitespaces between keywords
@@ -33,9 +32,9 @@ public class FindCommandParserTest {
     }
 
     @Test
-    public void parse_validRoom_returnsFindCommandWithRoomPredicate() throws Exception {
+    public void parse_validRoomFragment_returnsFindCommandWithUnifiedPredicate() {
         String userInput = "  #14-2  ";
-        FindCommand expectedCommand = new FindCommand(new RoomEqualsPredicate("#14-2"));
+        FindCommand expectedCommand = new FindCommand(new PersonContainsKeywordsPredicate(Arrays.asList("#14-2")));
         assertParseSuccess(parser, userInput, expectedCommand);
     }
 

--- a/src/test/java/seedu/address/model/person/PersonContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/PersonContainsKeywordsPredicateTest.java
@@ -19,14 +19,17 @@ public class PersonContainsKeywordsPredicateTest {
         List<String> firstPredicateKeywordList = Collections.singletonList("first");
         List<String> secondPredicateKeywordList = Arrays.asList("first", "second");
 
-        PersonContainsKeywordsPredicate firstPredicate = new PersonContainsKeywordsPredicate(firstPredicateKeywordList);
-        PersonContainsKeywordsPredicate secondPredicate = new PersonContainsKeywordsPredicate(secondPredicateKeywordList);
+        PersonContainsKeywordsPredicate firstPredicate =
+                new PersonContainsKeywordsPredicate(firstPredicateKeywordList);
+        PersonContainsKeywordsPredicate secondPredicate =
+                new PersonContainsKeywordsPredicate(secondPredicateKeywordList);
 
         // same object -> returns true
         assertTrue(firstPredicate.equals(firstPredicate));
 
         // same values -> returns true
-        PersonContainsKeywordsPredicate firstPredicateCopy = new PersonContainsKeywordsPredicate(firstPredicateKeywordList);
+        PersonContainsKeywordsPredicate firstPredicateCopy =
+                new PersonContainsKeywordsPredicate(firstPredicateKeywordList);
         assertTrue(firstPredicate.equals(firstPredicateCopy));
 
         // different types -> returns false

--- a/src/test/java/seedu/address/model/person/PersonContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/PersonContainsKeywordsPredicateTest.java
@@ -1,0 +1,68 @@
+package seedu.address.model.person;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.testutil.PersonBuilder;
+
+public class PersonContainsKeywordsPredicateTest {
+
+    @Test
+    public void equals() {
+        List<String> firstPredicateKeywordList = Collections.singletonList("first");
+        List<String> secondPredicateKeywordList = Arrays.asList("first", "second");
+
+        PersonContainsKeywordsPredicate firstPredicate = new PersonContainsKeywordsPredicate(firstPredicateKeywordList);
+        PersonContainsKeywordsPredicate secondPredicate = new PersonContainsKeywordsPredicate(secondPredicateKeywordList);
+
+        // same object -> returns true
+        assertTrue(firstPredicate.equals(firstPredicate));
+
+        // same values -> returns true
+        PersonContainsKeywordsPredicate firstPredicateCopy = new PersonContainsKeywordsPredicate(firstPredicateKeywordList);
+        assertTrue(firstPredicate.equals(firstPredicateCopy));
+
+        // different types -> returns false
+        assertFalse(firstPredicate.equals(1));
+
+        // null -> returns false
+        assertFalse(firstPredicate.equals(null));
+
+        // different keywords -> returns false
+        assertFalse(firstPredicate.equals(secondPredicate));
+    }
+
+    @Test
+    public void test_matchesNameRoomOrTag_returnsTrue() {
+        Person person = new PersonBuilder().withName("Alex Yeoh").withRoom("#14-203-D")
+                .withTags("friends", "neighbours").build();
+
+        assertTrue(new PersonContainsKeywordsPredicate(Collections.singletonList("al")).test(person));
+        assertTrue(new PersonContainsKeywordsPredicate(Collections.singletonList("#14-2")).test(person));
+        assertTrue(new PersonContainsKeywordsPredicate(Collections.singletonList("frie")).test(person));
+    }
+
+    @Test
+    public void test_doesNotMatchNameRoomOrTag_returnsFalse() {
+        Person person = new PersonBuilder().withName("Alex Yeoh").withRoom("#14-203-D")
+                .withTags("friends", "neighbours").build();
+
+        assertFalse(new PersonContainsKeywordsPredicate(Collections.singletonList("xyz")).test(person));
+    }
+
+    @Test
+    public void toStringMethod() {
+        List<String> keywords = List.of("keyword1", "keyword2");
+        PersonContainsKeywordsPredicate predicate = new PersonContainsKeywordsPredicate(keywords);
+
+        String expected = PersonContainsKeywordsPredicate.class.getCanonicalName() + "{keywords=" + keywords + "}";
+        assertEquals(expected, predicate.toString());
+    }
+}


### PR DESCRIPTION
Description of Changes
This PR extends the find command to support searching by tags in addition to name and room, without requiring any prefix.

What problem is addressed
Previously, find supported fragmented matching for name/room but did not allow searching by tag. Users had no direct way to locate residents using tag keywords such as friends, asthma, etc.

What was changed
Added a unified predicate: PersonContainsKeywordsPredicate.
Performs case-insensitive, partial matching across:
person name
room value
tag names
Uses OR semantics: a person is returned if any keyword matches any of those fields.
Updated FindCommandParser to always parse find inputs into the unified predicate (no special prefixes required).
Updated FindCommand usage message to reflect name/room/tag keyword search.
Added/updated tests:
FindCommandParserTest now validates parsing to the unified predicate.
FindCommandTest includes tag-based matching assertions.
Added PersonContainsKeywordsPredicateTest for predicate behavior and equality/toString coverage.
Example behavior
find al → matches by name fragment (Alex)
find #14-2 → matches by room fragment (#14-203-D)
find friend → matches by tag fragment (friends)
Checklist

Tests have been added for the changes made.

Documentation has been updated where applicable, including docstrings for API changes. (UG, DG, portfolio, docstrings)

Code follows the style guidelines of this project (run
./gradlew check
to verify).