### PR TITLE
Disallow spaces in tag names

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -132,6 +132,7 @@ Format: `add n/NAME [p/PHONE] [e/EMAIL] r/ROOM [t/TAG]…​ [-newtag]`
 * Built-in tags are `vegetarian`, `vegan`, `halal`, and `allergies`.
 * All tags are case-sensitive. For example, `study-group` and `Study-Group` are treated as different tags.
 * Kebab-case is recommended for consistency, e.g. `study-group`.
+* **Spaces are not allowed in tags.** Use hyphens to separate words instead (e.g., `study-group` not `study group`).
 * To create a new custom tag while adding a resident, include `-newtag` in the same command.
 * If you include `-newtag` for a tag that already exists, RACE will still accept the command. No duplicate tag is created.
 
@@ -154,6 +155,7 @@ Tags help you label residents with quick categories or notes.
 * The four built-in tags are always available: `vegetarian`, `vegan`, `halal`, `allergies`.
 * Any other tag is treated as a custom tag.
 * Custom tags must already exist before you can reuse them.
+* **Spaces are not allowed in tags.** Use hyphens to separate words (e.g., `project-team` not `project team`).
 * If you want to introduce a brand-new custom tag, use `-newtag` together with `add` or `edit`.
 * If you use `-newtag` for an already existing tag, the command still succeeds normally.
 
@@ -504,6 +506,9 @@ _Details coming soon ..._
 
 **Q**: Are tags case-sensitive?<br>
 **A**: Yes. `study-group` and `Study-Group` are treated as different tags. For consistency, we recommend entering tags in kebab-case.
+
+**Q**: Can tags contain spaces?<br>
+**A**: No. Tags cannot contain spaces. Use hyphens to separate words instead (e.g., `study-group` instead of `study group`).
 
 **Q**: What happens if I use `-newtag` for a tag that already exists?<br>
 **A**: Nothing extra happens. The command still works normally, and RACE simply reuses the existing tag.

--- a/src/main/java/seedu/address/model/tag/Tag.java
+++ b/src/main/java/seedu/address/model/tag/Tag.java
@@ -10,9 +10,9 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 public class Tag {
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Tags should only contain letters, numbers, spaces, and hyphens, and it should not be blank. "
-                    + "Kebab-case is recommended for consistency.";
-    private static final String VALIDATION_REGEX = "[A-Za-z0-9][A-Za-z0-9 -]*";
+            "Tags should only contain letters, numbers, and hyphens, and it should not be blank. "
+                    + "Hyphens may be used to separate words (e.g., study-group). Spaces are not allowed.";
+    private static final String VALIDATION_REGEX = "[A-Za-z0-9][A-Za-z0-9-]*";
 
     private final String tagName;
 

--- a/src/test/java/seedu/address/model/tag/TagTest.java
+++ b/src/test/java/seedu/address/model/tag/TagTest.java
@@ -16,6 +16,10 @@ public class TagTest {
     public void constructor_invalidTagName_throwsIllegalArgumentException() {
         String invalidTagName = "";
         assertThrows(IllegalArgumentException.class, () -> new Tag(invalidTagName));
+
+        // spaces not allowed
+        assertThrows(IllegalArgumentException.class, () -> new Tag("study group"));
+        assertThrows(IllegalArgumentException.class, () -> new Tag("halal food"));
     }
 
     @Test


### PR DESCRIPTION
## Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR closes any issues, list them here by number (e.g., Closes #123).
-->
Closes #220 

Restrict user from creating tags with spaces, e.g. "halal food". 
* There are less restrictive ways to handle this but too complex (e.g., using quotes t/"halal food"). 
* This naming restriction is like git's branches or tags.

## Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## Checklist

- [x] Tests have been added for the changes made.
- [x] Documentation has been updated where applicable, including docstrings for API changes. (UG, DG, portfolio, docstrings)
- [x] Code follows the style guidelines of this project (run `./gradlew check` to verify).
