### PR TITLE
Start making DG more RACE centric

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -4,8 +4,10 @@
   pageNav: 3
 ---
 
-# AB-3 Developer Guide
-
+# RACE Developer Guide
+This guide documents **RACE** (Resident Administration & Contact Explorer). This repository extends the AB3 architecture with additional domain concepts such as room-based resident records, tag registries, comments, and list sorting behaviours that are not present in stock AB3.
+When reading older AB3-oriented diagrams or descriptions, interpret them as the high-level structure of the app; refer to the current `Model`, `Storage`, and `Logic` sections for RACE-specific details.
+Contributors should prefer updating diagrams and explanations alongside feature changes to avoid documentation drift.
 <!-- * Table of Contents -->
 <page-nav-print />
 


### PR DESCRIPTION
## Summary

Closes #

This PR updates the Developer Guide with a short introductory section that clarifies RACE’s relationship to AB3 and sets expectations for readers when some legacy AB3 framing remains elsewhere in the document.

## Description of Changes

- Added an **introductory paragraph** near the top of `docs/DeveloperGuide.md` explaining that the guide documents **RACE** and that parts of the document may still follow the original AB3 structure.
- Noted that **planned follow-up work** includes aligning terminology, removing stale placeholders, and updating diagrams where RACE behaviour diverges from stock AB3.
- Briefly explained that the codebase extends AB3 with **RACE-specific concepts** (e.g. room-centric resident records, tags/registry, comments, list sorting) and that contributors should update docs alongside code to avoid drift.

**Why:** Reduces confusion for new contributors and reviewers who expect “pure AB3” documentation, without requiring a full rewrite in this iteration.

## Checklist

- [ ] Tests have been added for the changes made.
- [x] Documentation has been updated where applicable, including docstrings for API changes. (UG, DG, portfolio, docstrings)
- [ ] Code follows the style guidelines of this project (run `./gradlew check` to verify).
