### PR TITLE
Preserve list context after edit command and update tests

### DIFF
--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -7,7 +7,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_NEWTAG;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ROOM;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
-import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import java.util.Collections;
 import java.util.HashSet;
@@ -146,7 +145,6 @@ public class EditCommand extends Command {
             model.addCustomTags(editPersonDescriptor.getTags().get());
         }
         model.setPerson(personToEdit, editedPerson);
-        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
         return new CommandResult(String.format(MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPerson)));
     }
 

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -14,9 +14,9 @@ import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
-import java.util.Comparator;
-
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import java.util.Comparator;
 
 import org.junit.jupiter.api.Test;
 
@@ -105,7 +105,7 @@ public class EditCommandTest {
     }
 
     @Test
-    public void execute_sortedList_retainsSortContext_success() throws Exception {
+    public void execute_sortedListRetainsContext_success() throws Exception {
         model.updateFilteredPersonList(Model.PREDICATE_SHOW_ALL_PERSONS, ROOM_COMPARATOR);
         EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON,
                 new EditPersonDescriptorBuilder().withPhone("95551234").build());

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -14,6 +14,8 @@ import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
+import java.util.Comparator;
+
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import org.junit.jupiter.api.Test;
@@ -34,6 +36,7 @@ import seedu.address.testutil.PersonBuilder;
  */
 public class EditCommandTest {
 
+    private static final Comparator<Person> ROOM_COMPARATOR = (p1, p2) -> p1.getRoom().compareTo(p2.getRoom());
     private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
 
     @Test
@@ -88,16 +91,31 @@ public class EditCommandTest {
         showPersonAtIndex(model, INDEX_FIRST_PERSON);
 
         Person personInFilteredList = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
-        Person editedPerson = new PersonBuilder(personInFilteredList).withName(VALID_NAME_BOB).build();
+        Person editedPerson = new PersonBuilder(personInFilteredList).withPhone(VALID_PHONE_BOB).build();
         EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON,
-                new EditPersonDescriptorBuilder().withName(VALID_NAME_BOB).build());
+                new EditPersonDescriptorBuilder().withPhone(VALID_PHONE_BOB).build());
 
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPerson));
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
         expectedModel.setPerson(model.getFilteredPersonList().get(0), editedPerson);
+        showPersonAtIndex(expectedModel, INDEX_FIRST_PERSON);
 
         assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_sortedList_retainsSortContext_success() throws Exception {
+        model.updateFilteredPersonList(Model.PREDICATE_SHOW_ALL_PERSONS, ROOM_COMPARATOR);
+        EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON,
+                new EditPersonDescriptorBuilder().withPhone("95551234").build());
+        editCommand.execute(model);
+
+        for (int i = 1; i < model.getFilteredPersonList().size(); i++) {
+            Person previous = model.getFilteredPersonList().get(i - 1);
+            Person current = model.getFilteredPersonList().get(i);
+            assertTrue(previous.getRoom().compareTo(current.getRoom()) <= 0);
+        }
     }
 
     @Test


### PR DESCRIPTION
## Summary

Fixes list-context reset after `edit` so users stay in the same displayed
ordering/context after a successful edit.

Closes #223

## Description of Changes

- Removed the forced list reset in `EditCommand` that always switched the
  UI back to the default "show all" context after edit.
- Preserved index semantics: `edit INDEX ...` still resolves `INDEX`
  against the currently displayed list.
- Kept post-edit behavior in the same logical view context (e.g., sorted
  list stays sorted instead of unexpectedly reverting).
- Updated tests in `EditCommandTest` to cover and guard against regression:
  - filtered-list edit success under retained context
  - sorted-list edit retains ordering context after edit

### Manual smoke test (recommended)

1. `list -sort r/`
2. `edit 2 p/90001111`
3. Verify displayed order remains sorted by room and does not reset to
   default order.

## Checklist

- [x] Tests have been added for the changes made.
- [ ] Documentation has been updated where applicable, including docstrings for API changes. (UG, DG, portfolio, docstrings)
- [x] Code follows the style guidelines of this project (run `./gradlew check` to verify).