### PR TITLE
Align user guide with current command behavior

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -215,8 +215,6 @@ When sorting IS used:
 * Supported sort prefixes:
   * `n/` (name)
   * `r/` (room)
-  * `p/` (phone)
-  * `e/` (email)
 * If you omit `-sort`, residents are shown in the order stored in the app (typically the order they were added).
 
 </box>
@@ -233,7 +231,7 @@ When sorting IS used:
 
 **Tips:**
 * Use `list -sort PREFIX` to review residents in a predictable order.
-* After [`find`](#finding-residents-by-name-or-room-find), any active **sort order is cleared** until you run `list -sort ...` again.
+* After [`find`](#finding-residents-by-keyword-name-room-or-tag-find), any active **sort order is cleared** until you run `list -sort ...` again.
 
 </box>
 
@@ -546,7 +544,7 @@ _Details coming soon ..._
 ### Saving and data
 
 **Q**: Does the app save automatically?<br>
-**A**: Yes. Successful changes are saved automatically.
+**A**: Yes. Data is saved automatically after every successful command.
 
 **Q**: Where is my data stored?<br>
 **A**: Your data is stored in `data/addressbook.json`, in the same folder as the `.jar` file you use to open the app.


### PR DESCRIPTION
## Summary

Aligns the User Guide with current command behavior so peer testers get
accurate instructions and expectations.

## Description of Changes

- Updated `docs/UserGuide.md` to remove list sort prefix drift:
  - `list -sort` documented as supporting only `n/` and `r/` (matches parser behavior).
- Fixed stale internal anchor in the list tips section:
  - `find` reference now points to the current `find` section heading.
- Aligned save FAQ wording with actual runtime behavior:
  - clarified autosave after every successful command.

### Why this is needed

Some UG lines had fallen out of sync with implementation details, which
can cause confusion during manual testing and acceptance checks.

This PR is documentation-only and does not change application logic.

## Checklist

- [ ] Tests have been added for the changes made. *(N/A — documentation-only changes)*
- [x] Documentation has been updated where applicable, including docstrings for API changes. (UG, DG, portfolio, docstrings)
- [ ] Code follows the style guidelines of this project (run `./gradlew check` to verify). *(N/A — docs-only PR)*