### PR TITLE
Add error message for duplicate indices in delete command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -24,11 +24,12 @@ public class DeleteCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Deletes one or more persons identified by index numbers used in the displayed person list.\n"
-            + "Parameters: INDEX[,INDEX]... (each index must be a positive integer)\n"
+            + "Parameters: INDEX[,INDEX]... (each index must be a positive integer; no duplicate indices)\n"
             + "Example: " + COMMAND_WORD + " 1,3,5";
 
     public static final String MESSAGE_DELETE_PERSON_SUCCESS = "Deleted Person: %1$s";
     public static final String MESSAGE_DELETE_PERSONS_SUCCESS = "Deleted Persons:\n%1$s";
+    public static final String MESSAGE_DUPLICATE_INDICES = "Duplicate indices are not allowed.";
 
     private final List<Index> targetIndices;
 
@@ -46,19 +47,18 @@ public class DeleteCommand extends Command {
         // Use the currently filtered list so the displayed indices map to the same persons.
         List<Person> lastShownList = model.getFilteredPersonList();
 
-        // Track indices we've already processed so duplicate indices don't cause double-deletes.
         Set<Integer> seenZeroBasedIndices = new HashSet<>();
-        // Collect persons to delete first, so we can delete after validation/deduping.
+        for (Index targetIndex : targetIndices) {
+            if (!seenZeroBasedIndices.add(targetIndex.getZeroBased())) {
+                throw new CommandException(MESSAGE_DUPLICATE_INDICES);
+            }
+        }
+
         List<Person> personsToDelete = new ArrayList<>();
         for (Index targetIndex : targetIndices) {
             int zeroBasedIndex = targetIndex.getZeroBased();
             if (zeroBasedIndex >= lastShownList.size()) {
                 throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
-            }
-            // Happens when the user provides duplicate indices (e.g., `delete 1 1 2`).
-            // We skip already-processed indices to avoid deleting the same person twice.
-            if (!seenZeroBasedIndices.add(zeroBasedIndex)) {
-                continue;
             }
             personsToDelete.add(lastShownList.get(zeroBasedIndex));
         }

--- a/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
@@ -3,7 +3,9 @@ package seedu.address.logic.parser;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import seedu.address.commons.core.index.Index;
@@ -37,8 +39,17 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
             if (indices.isEmpty()) {
                 throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
             }
+            Set<Integer> seenZeroBased = new HashSet<>();
+            for (Index index : indices) {
+                if (!seenZeroBased.add(index.getZeroBased())) {
+                    throw new ParseException(DeleteCommand.MESSAGE_DUPLICATE_INDICES);
+                }
+            }
             return new DeleteCommand(indices);
         } catch (ParseException pe) {
+            if (DeleteCommand.MESSAGE_DUPLICATE_INDICES.equals(pe.getMessage())) {
+                throw pe;
+            }
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE), pe);
         } catch (IllegalArgumentException iae) {

--- a/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
@@ -83,6 +83,12 @@ public class DeleteCommandTest {
     }
 
     @Test
+    public void execute_duplicateIndices_throwsCommandException() {
+        DeleteCommand deleteCommand = new DeleteCommand(List.of(INDEX_FIRST_PERSON, INDEX_FIRST_PERSON));
+        assertCommandFailure(deleteCommand, model, DeleteCommand.MESSAGE_DUPLICATE_INDICES);
+    }
+
+    @Test
     public void execute_multipleValidIndicesUnfilteredList_success() {
         Person firstPersonToDelete = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
         Person thirdPersonToDelete = model.getFilteredPersonList().get(INDEX_THIRD_PERSON.getZeroBased());

--- a/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
@@ -40,5 +40,8 @@ public class DeleteCommandParserTest {
         assertParseFailure(parser, ",1", String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
         assertParseFailure(parser, "1, ,2", String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
         assertParseFailure(parser, "1,,2", String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+
+        assertParseFailure(parser, "1,1", DeleteCommand.MESSAGE_DUPLICATE_INDICES);
+        assertParseFailure(parser, "1,2,1", DeleteCommand.MESSAGE_DUPLICATE_INDICES);
     }
 }


### PR DESCRIPTION
## Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR closes any issues, list them here by number (e.g., Closes #123).
-->
Closes #310

## Description of Changes
Changes:
1. Delete Command 

- Added MESSAGE_DUPLICATE_INDICES = "Duplicate indices are not allowed."
- Replaced the silent skip with a CommandException when duplicates appear (covers tests or code that build DeleteCommand with duplicate Indexes).
- Documented no duplicate indices in MESSAGE_USAGE.
2. DeleteCommandParser 
- After parsing the comma-separated list, checks for duplicate zero-based indices and throws ParseException with the same message so normal input like delete 1,1 fails at parse time.
- The existing catch (ParseException) was wrapping every ParseException, including this one. It now rethrows when the message is MESSAGE_DUPLICATE_INDICES so the user sees the duplicate message, not the generic “Invalid command format!”.

3. Tests
- Parser: 1,1 and 1,2,1 → parse failure with MESSAGE_DUPLICATE_INDICES.
- Command: execute_duplicateIndices_throwsCommandException for List.of(INDEX_FIRST_PERSON, INDEX_FIRST_PERSON).

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## Checklist

- [ ] Tests have been added for the changes made.
- [ ] Documentation has been updated where applicable, including docstrings for API changes. (UG, DG, portfolio, docstrings)
- [ ] Code follows the style guidelines of this project (run `./gradlew check` to verify).
