### PR TITLE
Make name and email case sensitive

### DIFF
--- a/src/main/java/seedu/address/model/person/Email.java
+++ b/src/main/java/seedu/address/model/person/Email.java
@@ -3,6 +3,8 @@ package seedu.address.model.person;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.AppUtil.checkArgument;
 
+import java.util.Locale;
+
 /**
  * Represents a Person's email in the address book.
  * Guarantees: immutable; is valid as declared in {@link #isValidEmail(String)}
@@ -70,12 +72,12 @@ public class Email {
 
         Email otherEmail = (Email) other;
         assert otherEmail != null : "After instanceof check, otherEmail should not be null";
-        return value.equals(otherEmail.value);
+        return value.equalsIgnoreCase(otherEmail.value);
     }
 
     @Override
     public int hashCode() {
-        return value.hashCode();
+        return value.toLowerCase(Locale.ROOT).hashCode();
     }
 
 }

--- a/src/main/java/seedu/address/model/person/Name.java
+++ b/src/main/java/seedu/address/model/person/Name.java
@@ -3,6 +3,8 @@ package seedu.address.model.person;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.AppUtil.checkArgument;
 
+import java.util.Locale;
+
 /**
  * Represents a Person's name in the address book.
  * Guarantees: immutable; is valid as declared in {@link #isValidName(String)}
@@ -57,12 +59,12 @@ public class Name {
 
         Name otherName = (Name) other;
         assert otherName != null : "After instanceof check, otherName should not be null";
-        return fullName.equals(otherName.fullName);
+        return fullName.equalsIgnoreCase(otherName.fullName);
     }
 
     @Override
     public int hashCode() {
-        return fullName.hashCode();
+        return fullName.toLowerCase(Locale.ROOT).hashCode();
     }
 
 }

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -70,8 +70,9 @@ public class Person {
     }
 
     /**
-     * Returns true if both persons cannot coexist in the address book because they share the same name,
-     * room number, or (when both are non-empty) the same phone number or email.
+     * Returns true if both persons cannot coexist in the address book because they share the same name
+     * (case-insensitive), room number, or (when both are non-empty) the same phone number or email
+     * (emails compared case-insensitively when both are non-empty).
      */
     public boolean isSamePerson(Person otherPerson) {
         if (otherPerson == this) {

--- a/src/main/java/seedu/address/model/person/UniquePersonList.java
+++ b/src/main/java/seedu/address/model/person/UniquePersonList.java
@@ -13,8 +13,9 @@ import seedu.address.model.person.exceptions.PersonNotFoundException;
 
 /**
  * A list of persons that enforces uniqueness between its elements and does not allow nulls.
- * A person is considered unique by comparing using {@code Person#isSamePerson(Person)} (same name, room, or
- * non-empty phone/email). Adding uses that check; {@link #setPerson(Person, Person)} skips the person being replaced
+ * A person is considered unique by comparing using {@code Person#isSamePerson(Person)} (same name ignoring case,
+ * room, or non-empty phone or case-insensitively equal email). Adding uses that check;
+ * {@link #setPerson(Person, Person)} skips the person being replaced
  * when checking conflicts. Removal uses {@code Person#equals(Object)} so the person with exactly the same fields is
  * removed.
  * <p>

--- a/src/main/java/seedu/address/model/person/exceptions/DuplicatePersonException.java
+++ b/src/main/java/seedu/address/model/person/exceptions/DuplicatePersonException.java
@@ -1,7 +1,8 @@
 package seedu.address.model.person.exceptions;
 
 /**
- * Signals that the operation will result in duplicate Persons (same name, room, or non-empty phone/email).
+ * Signals that the operation will result in duplicate Persons (same name ignoring case, room, or non-empty
+ * phone or case-insensitively equal email).
  */
 public class DuplicatePersonException extends RuntimeException {
     public DuplicatePersonException() {

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -57,6 +57,42 @@ public class AddCommandTest {
     }
 
     @Test
+    public void execute_duplicateNameDifferingOnlyInCase_throwsCommandException() {
+        Person existingPerson = new PersonBuilder().withName("John Doe")
+                .withPhone("91111111")
+                .withEmail("john@example.com")
+                .withRoom("#1-101-A")
+                .build();
+        Person duplicateName = new PersonBuilder().withName("john doe")
+                .withPhone("92222222")
+                .withEmail("other@example.com")
+                .withRoom("#2-202-B")
+                .build();
+        AddCommand addCommand = new AddCommand(duplicateName);
+
+        assertThrows(CommandException.class, AddCommand.MESSAGE_DUPLICATE_NAME, () ->
+                addCommand.execute(new ModelStubWithPerson(existingPerson)));
+    }
+
+    @Test
+    public void execute_duplicateEmailDifferingOnlyInCase_throwsCommandException() {
+        Person existingPerson = new PersonBuilder().withName("Alpha")
+                .withPhone("93333333")
+                .withEmail("e13@gmail.com")
+                .withRoom("#3-303-C")
+                .build();
+        Person duplicateEmail = new PersonBuilder().withName("Beta")
+                .withPhone("94444444")
+                .withEmail("E13@GMAIL.COM")
+                .withRoom("#4-404-D")
+                .build();
+        AddCommand addCommand = new AddCommand(duplicateEmail);
+
+        assertThrows(CommandException.class, AddCommand.MESSAGE_DUPLICATE_EMAIL, () ->
+                addCommand.execute(new ModelStubWithPerson(existingPerson)));
+    }
+
+    @Test
     public void execute_duplicatePhone_throwsCommandException() {
         Person existingPerson = new PersonBuilder().withName("Alice Alpha")
                 .withPhone("90000001")

--- a/src/test/java/seedu/address/model/person/EmailTest.java
+++ b/src/test/java/seedu/address/model/person/EmailTest.java
@@ -84,5 +84,8 @@ public class EmailTest {
 
         // different values -> returns false
         assertFalse(email.equals(new Email("other.valid@email")));
+
+        // same address, different case -> returns true
+        assertTrue(email.equals(new Email("VALID@EMAIL")));
     }
 }

--- a/src/test/java/seedu/address/model/person/EmailTest.java
+++ b/src/test/java/seedu/address/model/person/EmailTest.java
@@ -1,5 +1,6 @@
 package seedu.address.model.person;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.testutil.Assert.assertThrows;
@@ -87,5 +88,10 @@ public class EmailTest {
 
         // same address, different case -> returns true
         assertTrue(email.equals(new Email("VALID@EMAIL")));
+    }
+
+    @Test
+    public void hashCode_sameAddressDifferentCase_sameHashCode() {
+        assertEquals(new Email("valid@email").hashCode(), new Email("VALID@EMAIL").hashCode());
     }
 }

--- a/src/test/java/seedu/address/model/person/NameTest.java
+++ b/src/test/java/seedu/address/model/person/NameTest.java
@@ -56,5 +56,8 @@ public class NameTest {
 
         // different values -> returns false
         assertFalse(name.equals(new Name("Other Valid Name")));
+
+        // same letters, different case -> returns true
+        assertTrue(name.equals(new Name("VALID NAME")));
     }
 }

--- a/src/test/java/seedu/address/model/person/PersonTest.java
+++ b/src/test/java/seedu/address/model/person/PersonTest.java
@@ -52,10 +52,14 @@ public class PersonTest {
                 .withEmail(VALID_EMAIL_BOB).withRoom(VALID_ROOM_BOB).build();
         assertFalse(ALICE.isSamePerson(editedAlice));
 
-        // name differs in case; no shared name, room, phone, or email -> returns false
+        // same name differing only in case -> still treated as the same person
         Person editedBob = new PersonBuilder(BOB).withName(VALID_NAME_BOB.toLowerCase()).withPhone("99999999")
                 .withEmail("unique@example.com").withRoom("#12-120-F").build();
-        assertFalse(BOB.isSamePerson(editedBob));
+        assertTrue(BOB.isSamePerson(editedBob));
+
+        // same email differing only in case -> still treated as the same person
+        Person aliceDifferentEmailCase = new PersonBuilder(ALICE).withEmail("ALICE@EXAMPLE.COM").build();
+        assertTrue(ALICE.isSamePerson(aliceDifferentEmailCase));
 
         // different name (trailing space); no overlapping identity fields -> returns false
         String nameWithTrailingSpaces = VALID_NAME_BOB + " ";


### PR DESCRIPTION
## Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR closes any issues, list them here by number (e.g., Closes #123).
-->
Closes #299 

## Description of Changes

1. Name — only casing differs (should be rejected)
Add a resident, then try another whose name is the same letters but different case (phone/room/email all different so the clash is clearly from the name):

add n/John Doe r/#01-101-A p/90000001 e/john1@example.com
add n/john doe r/#02-202-B p/90000002 e/john2@example.com
Expected: something like “Name already exists in the address book.” (second command fails.)

2. Email — only casing differs (should be rejected)
Use different names and rooms so the only conflict is email:

add n/Alpha Tester r/#03-303-C p/91000001 e/e13@gmail.com
add n/Beta Tester r/#04-404-D p/91000002 e/E13@GMAIL.COM
Expected: “Email already exists in the address book.” (second command fails.)

3. Edit — would duplicate an existing name by case (should fail)
After (1), if John Doe is in the list, pick another person’s index (e.g. 2) and try to rename them to the same name in another case:

edit 2 n/john doe
Expected: duplicate name error (assuming person 2 is not already John Doe and the edit would clash with the existing John Doe).

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## Checklist

- [ ] Tests have been added for the changes made.
- [ ] Documentation has been updated where applicable, including docstrings for API changes. (UG, DG, portfolio, docstrings)
- [ ] Code follows the style guidelines of this project (run `./gradlew check` to verify).
