### PR TITLE
Relax room unit to allow 1-3 digits

### DIFF
--- a/src/main/java/seedu/address/model/person/Room.java
+++ b/src/main/java/seedu/address/model/person/Room.java
@@ -11,13 +11,13 @@ public class Room implements Comparable<Room> {
 
     public static final String MESSAGE_CONSTRAINTS =
             "Room must follow the format #FLOOR-UNIT[-LETTER], where floor is 1-2 digits, "
-                    + "unit is 2-3 digits, and letter is optional (e.g. #14-203-D or #14-20).";
+                    + "unit is 1-3 digits, and letter is optional (e.g. #14-203-D or #14-2).";
 
     /*
      * The first character of the room number must not be a whitespace,
      * otherwise " " (a blank string) becomes a valid input.
      */
-    public static final String VALIDATION_REGEX = "#[0-9]{1,2}-[0-9]{2,3}(-[A-Z])?";
+    public static final String VALIDATION_REGEX = "#[0-9]{1,2}-[0-9]{1,3}(-[A-Z])?";
 
     public final String value;
 

--- a/src/test/java/seedu/address/model/person/RoomTest.java
+++ b/src/test/java/seedu/address/model/person/RoomTest.java
@@ -29,11 +29,13 @@ public class RoomTest {
         assertFalse(Room.isValidRoom(" ")); // spaces only
         assertFalse(Room.isValidRoom("#14-203-d")); // letter must be uppercase
         assertFalse(Room.isValidRoom("#123-203-D")); // floor must be 1-2 digits
+        assertFalse(Room.isValidRoom("#14-2034-D")); // unit must be 1-3 digits
         assertFalse(Room.isValidRoom("14-203-D")); // missing leading '#'
 
         // valid rooms
         assertTrue(Room.isValidRoom("#14-203-D"));
-        assertTrue(Room.isValidRoom("#14-20-D")); // unit can be 2 or 3 digits
+        assertTrue(Room.isValidRoom("#14-2-D")); // unit can be 1, 2, or 3 digits
+        assertTrue(Room.isValidRoom("#14-20-D"));
         assertTrue(Room.isValidRoom("#1-000-A"));
         assertTrue(Room.isValidRoom("#14-20")); // letter is optional
         assertTrue(Room.isValidRoom("#99-999-Z"));


### PR DESCRIPTION
## Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR closes any issues, list them here by number (e.g., Closes #123).
-->
Closes #319 

## Description of Changes
Should be accepted
#14-2-D — unit is one digit
#14-20 — unit two digits, no letter
#14-203-D — unit three digits
#1-0-A — small floor + one-digit unit

Should be rejected
#14-2034-D — unit has four digits
#123-203-D — floor has three digits
#14-203-d — letter must be uppercase
14-203-D — missing leading #
Empty or only spaces after r/

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## Checklist

- [ ] Tests have been added for the changes made.
- [ ] Documentation has been updated where applicable, including docstrings for API changes. (UG, DG, portfolio, docstrings)
- [ ] Code follows the style guidelines of this project (run `./gradlew check` to verify).
