### PR TITLE
Fix bug where filtered list resets after comment

### DIFF
--- a/src/main/java/seedu/address/logic/commands/CommentCommand.java
+++ b/src/main/java/seedu/address/logic/commands/CommentCommand.java
@@ -1,7 +1,6 @@
 package seedu.address.logic.commands;
 
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
-import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import java.util.List;
 import java.util.Objects;
@@ -66,7 +65,6 @@ public class CommentCommand extends Command {
                 personToEdit.getRoom(), comment, personToEdit.getTags());
 
         model.setPerson(personToEdit, editedPerson);
-        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
 
         logger.fine("EditComment completed for index: " + index.getZeroBased());
         return new CommandResult(generateSuccessMessage(personToEdit, editedPerson));

--- a/src/test/java/seedu/address/logic/commands/CommentCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/CommentCommandTest.java
@@ -1,5 +1,6 @@
 package seedu.address.logic.commands;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_COMMENT_AMY;
@@ -7,10 +8,12 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_COMMENT_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_COMMENT_HANNAH;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
-import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
+import static seedu.address.testutil.TypicalPersons.ALICE;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import java.util.Collections;
 
 import org.junit.jupiter.api.Test;
 
@@ -22,6 +25,7 @@ import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
 import seedu.address.model.person.Comment;
 import seedu.address.model.person.Person;
+import seedu.address.model.person.PersonContainsKeywordsPredicate;
 import seedu.address.testutil.PersonBuilder;
 
 /**
@@ -134,7 +138,7 @@ public class CommentCommandTest {
 
     @Test
     public void execute_addCommentFilteredList_success() {
-        showPersonAtIndex(model, INDEX_FIRST_PERSON);
+        model.updateFilteredPersonList(new PersonContainsKeywordsPredicate(Collections.singletonList("Alice")));
 
         Person firstPerson = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
         Person editedPerson = new PersonBuilder(firstPerson).withComment(VALID_COMMENT_AMY).build();
@@ -148,8 +152,10 @@ public class CommentCommandTest {
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
         expectedModel.setPerson(firstPerson, editedPerson);
+        expectedModel.updateFilteredPersonList(new PersonContainsKeywordsPredicate(Collections.singletonList("Alice")));
 
         assertCommandSuccess(commentCommand, model, expectedMessage, expectedModel);
+        assertEquals(Collections.singletonList(editedPerson), model.getFilteredPersonList());
     }
 
     @Test
@@ -166,7 +172,8 @@ public class CommentCommandTest {
      */
     @Test
     public void execute_invalidPersonIndexFilteredList_failure() {
-        showPersonAtIndex(model, INDEX_FIRST_PERSON);
+        model.updateFilteredPersonList(new PersonContainsKeywordsPredicate(Collections.singletonList(ALICE.getName()
+                .fullName)));
         Index outOfBoundIndex = INDEX_SECOND_PERSON;
         // ensures that outOfBoundIndex is still in bounds of address book list
         assertTrue(outOfBoundIndex.getZeroBased() < model.getAddressBook().getPersonList().size());


### PR DESCRIPTION
## Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR closes any issues, list them here by number (e.g., Closes #123).
-->
Closes #294

The command previously reset the view to show all persons, causing the reported regression. Removed the unnecessary filtered-list reset and added a regression test to verify comment updates the selected person without clearing the existing find results or list context. 

## Description of Changes

## Checklist

- [x] Tests have been added for the changes made.
- [ ] Documentation has been updated where applicable, including docstrings for API changes. (UG, DG, portfolio, docstrings)
- [x] Code follows the style guidelines of this project (run `./gradlew check` to verify).
