### PR TITLE
Fix PED bug-report mismatches in help, usage, and email validation.

### DIFF
--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -44,7 +44,8 @@ public class EditCommand extends Command {
             + "[" + PREFIX_PHONE + "PHONE] "
             + "[" + PREFIX_EMAIL + "EMAIL] "
             + "[" + PREFIX_ROOM + "ROOM] "
-            + "[" + PREFIX_TAG + "TAG]...\n"
+            + "[" + PREFIX_TAG + "TAG]... "
+            + "[" + PREFIX_NEWTAG + "]\n"
             + "Example: " + COMMAND_WORD + " 1 "
             + PREFIX_PHONE + "91234567 "
             + PREFIX_EMAIL + "johndoe@example.com";

--- a/src/main/java/seedu/address/model/person/Email.java
+++ b/src/main/java/seedu/address/model/person/Email.java
@@ -26,8 +26,8 @@ public class Email {
             + "    - have each domain label consist of alphanumeric characters, separated only by hyphens, if any.";
     // alphanumeric and special characters
     private static final String ALPHANUMERIC_NO_UNDERSCORE = "[^\\W_]+"; // alphanumeric characters except underscore
-    private static final String LOCAL_PART_REGEX = "^" + ALPHANUMERIC_NO_UNDERSCORE + "([" + SPECIAL_CHARACTERS + "]"
-            + ALPHANUMERIC_NO_UNDERSCORE + ")*";
+    private static final String LOCAL_PART_REGEX = "^" + ALPHANUMERIC_NO_UNDERSCORE
+            + "([" + SPECIAL_CHARACTERS + "]*" + ALPHANUMERIC_NO_UNDERSCORE + ")*";
     private static final String DOMAIN_PART_REGEX = ALPHANUMERIC_NO_UNDERSCORE
             + "(-" + ALPHANUMERIC_NO_UNDERSCORE + ")*";
     private static final String DOMAIN_LAST_PART_REGEX = "(" + DOMAIN_PART_REGEX + "){2,}$"; // At least two chars

--- a/src/main/java/seedu/address/ui/HelpWindow.java
+++ b/src/main/java/seedu/address/ui/HelpWindow.java
@@ -15,7 +15,7 @@ import seedu.address.commons.core.LogsCenter;
  */
 public class HelpWindow extends UiPart<Stage> {
 
-    public static final String USERGUIDE_URL = "https://ay2526s2-cs2103t-t10-2.github.io/tp/";
+    public static final String USERGUIDE_URL = "https://ay2526s2-cs2103t-t10-2.github.io/tp/UserGuide.html";
     public static final String HELP_MESSAGE = "Refer to the user guide: " + USERGUIDE_URL;
 
     private static final Logger logger = LogsCenter.getLogger(HelpWindow.class);

--- a/src/test/java/seedu/address/model/person/EmailTest.java
+++ b/src/test/java/seedu/address/model/person/EmailTest.java
@@ -45,7 +45,7 @@ public class EmailTest {
         assertFalse(Email.isValidEmail("peter@jack@example.com")); // '@' symbol in local part
         assertFalse(Email.isValidEmail("-peterjack@example.com")); // local part starts with a hyphen
         assertFalse(Email.isValidEmail("peterjack-@example.com")); // local part ends with a hyphen
-        assertFalse(Email.isValidEmail("peter..jack@example.com")); // local part has two consecutive periods
+        assertTrue(Email.isValidEmail("peter..jack@example.com")); // consecutive special chars are allowed
         assertFalse(Email.isValidEmail("peterjack@example@com")); // '@' symbol in domain name
         assertFalse(Email.isValidEmail("peterjack@.example.com")); // domain name starts with a period
         assertFalse(Email.isValidEmail("peterjack@example.com.")); // domain name ends with a period
@@ -62,6 +62,8 @@ public class EmailTest {
         assertTrue(Email.isValidEmail("test@localhost")); // alphabets only
         assertTrue(Email.isValidEmail("123@145")); // numeric local part and domain name
         assertTrue(Email.isValidEmail("a1+be.d@example1.com")); // mixture of alphanumeric and special characters
+        assertTrue(Email.isValidEmail("a+-a@example.com")); // consecutive mixed special characters in local part
+        assertTrue(Email.isValidEmail("a++a@example.com")); // consecutive identical special characters in local part
         assertTrue(Email.isValidEmail("peter_jack@very-very-very-long-example.com")); // long domain name
         assertTrue(Email.isValidEmail("if.you.dream.it_you.can.do.it@example.com")); // long local part
         assertTrue(Email.isValidEmail("e1234567@u.nus.edu")); // more than one period in domain


### PR DESCRIPTION
This aligns in-app guidance with the User Guide by linking directly to `UserGuide.html` and documenting `edit`'s `-newtag` flag, and it updates email parsing to allow consecutive local-part special characters as described.

## Summary

Fixes three PED-reported inconsistencies between documented behavior and app behavior/messages for Help URL navigation, `edit` usage guidance, and email validation.

Closes #261  
Closes #274

## Description of Changes

- **Help window URL fix**
  - Updated `HelpWindow.USERGUIDE_URL` to point directly to:
    - `https://ay2526s2-cs2103t-t10-2.github.io/tp/UserGuide.html`
  - This ensures the Help popup and copy-to-clipboard URL match the intended UG page.

- **`edit` command error/help text fix**
  - Updated `EditCommand.MESSAGE_USAGE` so invalid-format guidance now includes optional `[-newtag]`.
  - This aligns parser error output with documented `edit` functionality.

- **Email validation behavior fix**
  - Adjusted local-part regex in `Email` to allow consecutive special characters (e.g. `a+-a@example.com`, `a++a@example.com`) while preserving existing start/end restrictions.
  - Added/updated `EmailTest` assertions to cover the corrected behavior.

## Checklist

- [x] Tests have been added for the changes made.
- [x] Documentation has been updated where applicable, including docstrings for API changes. (UG, DG, portfolio, docstrings)
- [ ] Code follows the style guidelines of this project (run `./gradlew check` to verify).