### PR TITLE
Preserve sort order when adding a new resident

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -190,8 +190,9 @@ The implementation relies on JavaFX's `SortedList`, which is initialized in `Mod
 2.  `ListCommand` is created with the field name and its comparator.
 3.  Upon execution, `ListCommand` calls `Model#updateFilteredPersonList(Predicate, Comparator)`.
 4.  `ModelManager` sets the filter on its `FilteredList` and the comparator on its `SortedList`.
-5.  If a simple `list` (without parameters) or a filtering command (like
-    `find`) is used, the sort comparator is reset to `null`.
+5.  If a simple `list` (without parameters) or `find` is used, the sort
+    comparator is reset to `null`. By contrast, `add` preserves any active
+    comparator while resetting the predicate to show all residents.
 
 The following sequence diagram shows the main interactions for `list -sort n/`.
 
@@ -201,7 +202,8 @@ The following sequence diagram shows the main interactions for `list -sort n/`.
 
 **Aspect: How sorting interacts with filtering**
 
-*   **Choice (current):** Sort order is reset when a new filter is applied unless specified via `list -sort <prefix>/`.
+*   **Choice (current):** Sort order is reset by `find` and plain `list`, but
+    preserved by `add` after a prior `list -sort <prefix>/`.
     *   Pros: Predictable behavior; users always see the list state they explicitly requested.
     *   Cons: Users cannot "keep" a sort order while performing multiple different searches without re-specifying the sort field.
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -144,6 +144,7 @@ Format: `add n/NAME [p/PHONE] [e/EMAIL] r/ROOM [t/TAG]…​ [-newtag]`
 * If you include `-newtag` for a tag that already exists, RACE will still accept the command. No duplicate tag is created.
 * Duplicate checks apply to `name`, `room`, `phone`, and `email`.
 * `phone` and `email` are optional, but if provided, they must still be unique among residents.
+* If you previously ran `list -sort ...`, adding a resident preserves that active sort order in the displayed list.
 
 </box>
 

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -114,7 +114,8 @@ public class ModelManager implements Model {
     @Override
     public void addPerson(Person person) {
         addressBook.addPerson(person);
-        updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+        // Preserve any active sort comparator after adding a new person.
+        filteredPersons.setPredicate(PREDICATE_SHOW_ALL_PERSONS);
         assert addressBook.hasPerson(person) : "Person should exist after addPerson";
     }
 

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -15,8 +15,10 @@ import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.GuiSettings;
+import seedu.address.model.person.Person;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.testutil.AddressBookBuilder;
+import seedu.address.testutil.PersonBuilder;
 
 public class ModelManagerTest {
 
@@ -86,6 +88,24 @@ public class ModelManagerTest {
     public void hasPerson_personInAddressBook_returnsTrue() {
         modelManager.addPerson(ALICE);
         assertTrue(modelManager.hasPerson(ALICE));
+    }
+
+    @Test
+    public void addPerson_whenSorted_preservesSortOrder() {
+        AddressBook addressBook = new AddressBookBuilder().withPerson(BENSON).withPerson(ALICE).build();
+        modelManager = new ModelManager(addressBook, new UserPrefs());
+        modelManager.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS,
+                (p1, p2) -> p1.getName().fullName.compareToIgnoreCase(p2.getName().fullName));
+
+        Person aaron = new PersonBuilder()
+                .withName("Aaron Aardvark")
+                .withRoom("#99-999-Y")
+                .withPhone("93334444")
+                .withEmail("aaron@example.com")
+                .build();
+        modelManager.addPerson(aaron);
+
+        assertEquals(aaron, modelManager.getFilteredPersonList().get(0));
     }
 
     @Test

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -15,8 +15,8 @@ import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.GuiSettings;
-import seedu.address.model.person.Person;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
+import seedu.address.model.person.Person;
 import seedu.address.testutil.AddressBookBuilder;
 import seedu.address.testutil.PersonBuilder;
 
@@ -94,8 +94,8 @@ public class ModelManagerTest {
     public void addPerson_whenSorted_preservesSortOrder() {
         AddressBook addressBook = new AddressBookBuilder().withPerson(BENSON).withPerson(ALICE).build();
         modelManager = new ModelManager(addressBook, new UserPrefs());
-        modelManager.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS,
-                (p1, p2) -> p1.getName().fullName.compareToIgnoreCase(p2.getName().fullName));
+        modelManager.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS, (p1, p2)
+                -> p1.getName().fullName.compareToIgnoreCase(p2.getName().fullName));
 
         Person aaron = new PersonBuilder()
                 .withName("Aaron Aardvark")


### PR DESCRIPTION
## Summary

This PR fixes a functionality bug where running `add` after `list -sort ...`
cleared the active sort order. As a result, newly added residents appeared at
the end of the list instead of being inserted in sorted position.

Closes #279

## Description of Changes

- Fix sort-preservation behavior in model update flow:
  - Update `ModelManager#addPerson` to preserve the active comparator while
    resetting the predicate to show all residents.
  - Avoid comparator reset previously introduced through
    `updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS)`.
- Add regression coverage:
  - Add `addPerson_whenSorted_preservesSortOrder` in `ModelManagerTest`.
  - Verify that after sorting by name, adding a resident keeps sorted insertion
    behavior.
- Update documentation for behavior clarity:
  - Update `UserGuide.md` to state that `add` preserves active sort order after
    `list -sort ...`.
  - Update `DeveloperGuide.md` to align implementation notes and design
    considerations with the new behavior.
- Validation performed:
  - Run targeted tests for model and add-command integration to ensure no
    regression in add behavior.

## Checklist

- [x] Tests have been added for the changes made.
- [x] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Code follows the style guidelines of this project (verified via existing checks and tests on touched files).
